### PR TITLE
Copy to clipboard button

### DIFF
--- a/cropshot.js
+++ b/cropshot.js
@@ -175,6 +175,20 @@
     }
   };
 
+  var copyToClipboard = function(secure_src) {
+    try {
+      var input = document.createElement("input");
+      input.value = src;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+    } catch(err) {
+      return;
+    }
+    dismissPreview();
+  }
+
   var dismissPreview = function () {
     previewContainer.classList.remove("show");
     previewContainer.innerHTML = "";
@@ -293,4 +307,5 @@
   window.addEventListener("mousedown", startCropping);
 
   window.dismissPreview = dismissPreview;
+  window.copyToClipboard = copyToClipboard;
 })();

--- a/index.html
+++ b/index.html
@@ -16,9 +16,11 @@
 		<div class="cropshot-preview">
 			<div class="cropshot-preview-line cropshot-preview-title">Your cropshot has been successfully saved !</div>
 			<img class="cropshot-preview-image cropshot-preview-line" src='{{secure_src}}'/>
-	        <a class="cropshot-preview-line" href='{{secure_src}}'>{{secure_src}}</a>
-	        <a class="cropshot-preview-line" href='{{src}}'>{{src}}</a>
-	        <div class="cropshot-preview-button" onclick="dismissPreview()">Close</div>
+			<a class="cropshot-preview-line" href='{{secure_src}}'>{{secure_src}}</a>
+			<div class="cropshot-preview-actions">
+				<button onclick="copyToClipboard('{{secure_src}}')">Copy to clipboard</button>
+				<button onclick="dismissPreview()">Close</button>
+			</div>
 		</div>
 
 	</script>

--- a/style.css
+++ b/style.css
@@ -80,12 +80,14 @@ body.croppable, #drop-area canvas {
   margin-bottom : 10px;
 }
 
-.cropshot-preview-button {
-  height: 30px;
-  line-height: 30px;
-  width: 80px;
-  float:right;
+.cropshot-preview-actions {
+  display: flex;
+  justify-content: center;
+}
 
+.cropshot-preview-actions button {
+  height: 35px;
+  margin: 0 5px;
   border: 1px solid rgb(100,100,100);
   border-radius: 1px;
 
@@ -98,7 +100,7 @@ body.croppable, #drop-area canvas {
   cursor: pointer;
 }
 
-.cropshot-preview-button:hover {
+.cropshot-preview-actions button:hover {
   background-color: rgb(140,140,140);
 }
 


### PR DESCRIPTION
Introducing a new button on the preview popup to copy cropshot url to the clipboard.

Complete blind coding here 🤷‍♂️ as I did not want to pollute screenletstore DB with testing images, but I nonetheless test the below snippet in instantHTML to make sure the trick was working.

```html
<html>
    <head>
        <title></title>
        <style>
            
        </style>
    </head>
    <body>
        <button onclick="copyToClipboard('voila voila')">Copy to clipboard</button>
        <script>
            window.copyToClipboard = function(src) {
                try {
                    var input = document.createElement("input");
                    input.value = src;
                    document.body.appendChild(input);
                    input.select();
                    document.execCommand('copy');
                    document.body.removeChild(input);
                } catch(err) {}
            }
        </script>
    </body>
</html>
```
I also removed the non secure url display to only keep the secure one.
Buttons will now look like this (high photoshop skills here!)

![image](https://user-images.githubusercontent.com/583204/82428103-4c085400-9a8a-11ea-9ce2-29ce19bfc0f8.png)


